### PR TITLE
cpp client: Fix some linter issues, random errors and wrong HTTP field

### DIFF
--- a/whisper_cpp_client.py
+++ b/whisper_cpp_client.py
@@ -20,7 +20,11 @@
 ##
 import pyautogui
 import pyperclip
-import os, time, queue, sys, re
+import os
+import time
+import queue
+import sys
+import re
 import webbrowser
 import tempfile
 import threading
@@ -80,7 +84,7 @@ actions = {
     r"^(peter|computer).? ": "chatGPT(q)"
     }
 
-def process_actions(tl):
+def process_actions(tl:str) -> bool:
     for input, action in actions.items():
         # look for action in list
         if s:=re.search(input, tl):
@@ -100,7 +104,7 @@ listening = True
 chatting = False
 
 # search text for hotkeys
-def process_hotkeys(txt):
+def process_hotkeys(txt: str) -> bool:
     global start
     for key,val in hotkeys.items():
         # if hotkey command
@@ -114,11 +118,11 @@ def process_hotkeys(txt):
             return True
     return False
 
-def gettext(f):
+def gettext(f:str) -> str:
     result = ['']
     if f and os.path.isfile(f):
         files = {'file': (f, open(f, 'rb'))}
-        data = {'temperature': '0.2', 'response-format': 'json'}
+        data = {'temperature': '0.2', 'response_format': 'json'}
 
         try:
             response = requests.post(cpp_url, files=files, data=data)
@@ -126,13 +130,14 @@ def gettext(f):
 
             # Parse the JSON response
             result = [response.json()]
+            return result[0]['text']
 
         except requests.exceptions.RequestException as e:
             sys.stderr.write(f"Error: {e}")
             return ""
-    return result[0]['text']
+        return ""
 
-def pastetext(t):
+def pastetext(t:str):
     # paste text in window
     if t == " you" or t == " Thanks for watching!" or "[" in t:
         return # ignoring you
@@ -149,7 +154,7 @@ say("Computer ready.")
 
 messages = [{ "role": "system", "content": "In this conversation between `user:` and `assistant:`, play the role of assistant. Reply as a helpful assistant." },]
 
-def chatGPT(prompt):
+def chatGPT(prompt: str):
     global chatting, messages
     messages.append({"role": "user", "content": prompt})
     completion = ""
@@ -199,7 +204,7 @@ def transcribe():
                 print(t)
                 # delete temporary audio file
                 try: os.remove(f)
-                except: pass
+                except Exception: pass
                 if not t: break
 
                 # get lower-case spoken command string
@@ -264,17 +269,17 @@ def quit():
     try:
         record_process.send_signal(signal.SIGINT)
         record_process.wait()
-    except:
+    except Exception:
         pass
     time.sleep(1)
     record_thread.join()
     # clean up
     try:
         while f := audio_queue.get_nowait():
-            sys.stderr.write("Removing temporary file: ", f)
+            sys.stderr.write(f"Removing temporary file: {f}")
             if f[:5] == "/tmp/": # safety check
                 os.remove(f)
-    except: pass
+    except Exception: pass
     sys.stderr.write("Freeing system resources.\n")
 
 if __name__ == '__main__':


### PR DESCRIPTION
I suggest to use some linter like Ruff, there's more issues but these are the uncontroversial small ones, what follows are suggestions not in this PR.

---

I suggest you merge the clients into one codebase, this is duplicating a lot of effort.

The ffmpeg in record.py seems to be an ancient dead version, I bumped it up like so:

```python
from ffmpeg import FFmpeg

            process = (
              FFmpeg()
                .input(self.audio_buffer, v=0, ss=ss, to=to)
                .output(fname)
            )
            logging.debug(f'ss: {ss}; to: {to}; fname:{fname}')
            process.execute()
```

I suggest you start using the logging facility instead of sys writes:

```python

import logging

logging.basicConfig(
	level=logging.DEBUG,
	format="%(asctime)s [%(levelname)s] %(message)s",
	handlers=[
#		logging.FileHandler('/tmp/nyx.log'),
		logging.StreamHandler()
	]
)
# INFO to stderr
#logging.getLogger().handlers[0].setLevel(logging.INFO)
```

And if you do migrate to `logging`, you can log exceptions as easily as this:
```python
        except Exception:
            logging.exception("Chat had a problem. Here's the error message.")
```

You (mostly) can fix the meter in record.py by doing this:
```python
            for x in range(75):
                print('*' * (75 - x), x, end='\x1b[1K\r')
            print("\r[%s] %.1f dB" % (meter_chars, (1 - level) * -53.0), end='')
...
        for x in range(75):
            print('*' * (75 - x), x, end='\x1b[1K\r')
```

You can deal with the hallucinations of the bigger models a bit better:

```python
t = cleanupHallucinations(gettext(f))

def cleanupHallucinations(text:str) -> str:
    splitLines = text.split("\n")
    returnString = ''
    for line in splitLines:
        line = line.strip()
        if line == 'Thank you.' or line == 'Thanks.' or line == 'Bye.' or line == 'Amen.':
            logging.warning(f'Removing line "{line}"')
            continue
        returnString += f"{line}\n"
    return returnString.strip('\n')
```

It's much nicer on the eyes to print with colors in the terminal for the necessary stuff like final output:

```python
from termcolor import colored

print(colored(t,'grey'))
```

I had my mic input a bit lowered so it took me a fair while to figure out why things don't work, either please bump it up by default to a considerably higher value (I'd rather have to lower it than debug why nothing works) or add some warnings/debug statements about it please.

I've also redesigned the command runs a bit so you can actually catch errors:

```python
actions = {
    r"^(nix|computer).? (run|execute|open|start|launch)(up)?( a| the)?.? ": "execute_command(program=q)",
    r"^(nix|computer).? search( the)?( you| web| google| bing| online)?(.com)? for ": "browser_open(query=q)"
}

def browser_open(*, query: str):
  webbrowser.open('https://you.com/search?q=' + re.sub(' ','%20',query))

def execute_command(*, program:str):
  if program not in commands[sys.platform]:
    logging.error(f"Command definition for '{colored(program,'red')}' was not found!")
    return
  try:
    os.system(commands[sys.platform][program])
  except Exception:
    logging.exception("Error executing command")
```