### PR TITLE
fix crash when OPENAI_API_KEY is not provided

### DIFF
--- a/whisper_cpp_client.py
+++ b/whisper_cpp_client.py
@@ -60,8 +60,10 @@ fallback_chat_url = "http://localhost:8888/v1"
 debug = False
 
 gpt_key = os.getenv("OPENAI_API_KEY")
-client = OpenAI(api_key=gpt_key)
-if not (gpt_key):
+client = None
+if gpt_key:
+    client = OpenAI(api_key=gpt_key)
+else:
     logging.debug("Export OPENAI_API_KEY if you want answers from ChatGPT.\n")
 gem_key = os.getenv("GENAI_TOKEN")
 if (gem_key):


### PR DESCRIPTION
If OPENAI_API_KEY environment variable is not provided, the app crashses with following error message:-

> OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
> /home/diwakar/.local/lib/python3.10/site-packages/openai/_client.py:126:raise OpenAIError(
> /home/diwakar/projects/whisper_dictation/whisper_cpp_client.py:63:client = OpenAI(api_key=gpt_key)

This PR restores making OPENAI_API_KEY optional.